### PR TITLE
AB#282877 - Add gamifyWidgetOpen fullscreen iframe overlay

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,4 +53,14 @@ export default class Optimove {
 
     optimoveSDK.API.reportEvent(event, params);
   }
+
+  async gamifyWidgetOpen(widgetUrl: string, userId?: string, token?: string): Promise<void> {
+    await this.ensureInitialization();
+    optimoveSDK.API.gamifyWidgetOpen(widgetUrl, userId, token);
+  }
+
+  async gamifyWidgetClose(): Promise<void> {
+    await this.ensureInitialization();
+    optimoveSDK.API.gamifyWidgetClose();
+  }
 }

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -1169,6 +1169,62 @@ export const optimoveSDK = (function () {
 		};
 	}
 
+	const gamifyModule = (() => {
+		let _overlay = null;
+
+		const open = (widgetUrl, userId, token) => {
+			if (_overlay) return;
+
+			const overlay = document.createElement('div');
+			overlay.id = 'optiGamifyOverlay';
+			overlay.style.cssText =
+				'position:fixed;top:0;left:0;width:100%;height:100%;' +
+				'z-index:99999;background:#000;border:none;margin:0;padding:0;';
+
+			const iframe = document.createElement('iframe');
+			iframe.src = widgetUrl;
+			iframe.style.cssText = 'width:100%;height:100%;border:none;';
+			iframe.allow = 'fullscreen';
+
+			overlay.appendChild(iframe);
+			document.body.appendChild(overlay);
+			_overlay = overlay;
+
+			function _handleMessage(event) {
+				try {
+					const data = typeof event.data === 'string'
+						? JSON.parse(event.data)
+						: event.data;
+
+					if (data && data.type === 'READY') {
+						iframe.contentWindow.postMessage(
+							JSON.stringify({ type: 'INIT', userId: userId || null, token: token || null }),
+							'*'
+						);
+					} else if (data && data.type === 'CLOSE') {
+						close();
+					}
+				} catch (e) {
+					// Ignore non-JSON messages from other origins
+				}
+			}
+
+			window.addEventListener('message', _handleMessage);
+			_overlay._messageHandler = _handleMessage;
+		};
+
+		const close = () => {
+			if (!_overlay) return;
+			if (_overlay._messageHandler) {
+				window.removeEventListener('message', _overlay._messageHandler);
+			}
+			document.body.removeChild(_overlay);
+			_overlay = null;
+		};
+
+		return { open, close };
+	})();
+
 	const realtimeModule = (() => {
 		let _popup;
 		let _executionInProcess = false;
@@ -2273,6 +2329,8 @@ export const optimoveSDK = (function () {
         // ### end
 		showRealtimePopup: realtimeModule.executePopup,
 		closeRealtimePopup: realtimeModule.closePopup,
+		gamifyWidgetOpen: (widgetUrl, userId, token) => gamifyModule.open(widgetUrl, userId, token),
+		gamifyWidgetClose: () => gamifyModule.close(),
 		openWebTestTool: () => {
 			let webSDKToolElm = document.getElementById("optimoveSdkWebTool");
 

--- a/src/sdk.js
+++ b/src/sdk.js
@@ -1175,6 +1175,15 @@ export const optimoveSDK = (function () {
 		const open = (widgetUrl, userId, token) => {
 			if (_overlay) return;
 
+			let widgetOrigin;
+			try {
+				const parsed = new URL(widgetUrl);
+				if (parsed.protocol !== 'https:') return;
+				widgetOrigin = parsed.origin;
+			} catch (e) {
+				return;
+			}
+
 			const overlay = document.createElement('div');
 			overlay.id = 'optiGamifyOverlay';
 			overlay.style.cssText =
@@ -1191,6 +1200,7 @@ export const optimoveSDK = (function () {
 			_overlay = overlay;
 
 			function _handleMessage(event) {
+				if (event.origin !== widgetOrigin) return;
 				try {
 					const data = typeof event.data === 'string'
 						? JSON.parse(event.data)
@@ -1199,13 +1209,13 @@ export const optimoveSDK = (function () {
 					if (data && data.type === 'READY') {
 						iframe.contentWindow.postMessage(
 							JSON.stringify({ type: 'INIT', userId: userId || null, token: token || null }),
-							'*'
+							widgetOrigin
 						);
 					} else if (data && data.type === 'CLOSE') {
 						close();
 					}
 				} catch (e) {
-					// Ignore non-JSON messages from other origins
+					// Ignore non-JSON messages
 				}
 			}
 


### PR DESCRIPTION
<img width="1075" height="686" alt="Screenshot 2026-04-30 at 15 40 01" src="https://github.com/user-attachments/assets/a33ace02-5f16-4dee-bd33-b5382697b9aa" />


## Summary

- Adds `gamifyWidgetOpen(widgetUrl, userId?, token?)` and `gamifyWidgetClose()` to the Web SDK, mirroring the API surface of the Android, iOS, and React Native SDKs
- Implemented as a new `gamifyModule` IIFE in `sdk.js`, following the existing module pattern (`realtimeModule`, `optimobileModule`)
- Widget is presented as a fullscreen fixed `<iframe>` overlay (100vw × 100vh, z-index 99999), matching the native modal sheet feel on mobile
- JS bridge handshake via `window.postMessage`: widget sends `READY` → SDK replies `INIT {userId, token}`; widget sends `CLOSE` → SDK removes the overlay
- TypeScript facade methods added to `index.ts` following the existing `async/await` + `ensureInitialization()` pattern

## Test plan

- [x] Open widget — fullscreen iframe overlay appears
- [x] READY → INIT handshake fires correctly (verified via DevTools)
- [x] CLOSE bridge message dismisses overlay
- [x] Double open is a no-op (only 1 overlay in DOM)
- [x] Re-open after close works cleanly
- [x] `npm run build` compiles with no TypeScript errors
- [x] ESLint passes with no warnings

## Notes

- `gamifyWidgetClose()` is exposed on the public API but in practice the widget always closes itself via the CLOSE bridge message — there is no visible close button since the iframe covers the full viewport
- Ticket: [AB#282877](https://mobius.visualstudio.com/7b12c5d6-c2cb-4957-9a09-46dfabf0bd18/_workitems/edit/282877)

🤖 Generated with [Claude Code](https://claude.com/claude-code)